### PR TITLE
Use relative paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY . .
 ENV PORT 8888
 EXPOSE 8888
 RUN npm run test
-CMD [ "node_modules/.bin/probot", "run", "index.js" ]
+CMD [ "./node_modules/.bin/probot", "run", "./index.js" ]


### PR DESCRIPTION
This requirement only presents itself after running the container with the proper environment passed to it! Sneaky.

Releasing as v0.0.2.